### PR TITLE
auto_ptr deprecated in c++11

### DIFF
--- a/src/codegenerator.cpp
+++ b/src/codegenerator.cpp
@@ -461,7 +461,11 @@ namespace highlight
 		for ( unsigned int i=0; i<langInfo.getRegexElements().size(); i++ )
 		{
 			RegexElement *regexElem = langInfo.getRegexElements() [i];
+#if __cplusplus >= 201103L
+			unique_ptr<Matcher> matcher ( regexElem->rePattern->createMatcher ( line ) );
+#else
 			auto_ptr<Matcher> matcher ( regexElem->rePattern->createMatcher ( line ) );
+#endif
 
 			while ( matcher->findNextMatch() )
 			{
@@ -1739,8 +1743,13 @@ namespace highlight
 			string res;
 			string replaceVar;
 
+#if __cplusplus >= 201103L
+			unique_ptr<Pattern> reDefPattern ( Pattern::compile ( "\\$[-\\w]+" ) );
+			unique_ptr<Matcher> m ( reDefPattern->createMatcher ( line.substr ( noParseCmd.size() +cmdPos ) ) );
+#else
 			auto_ptr<Pattern> reDefPattern ( Pattern::compile ( "\\$[-\\w]+" ) );
 			auto_ptr<Matcher> m ( reDefPattern->createMatcher ( line.substr ( noParseCmd.size() +cmdPos ) ) );
+#endif
 			while ( m.get() &&  m->findNextMatch() )
 			{
 				res+=line.substr ( noParseCmd.size() +cmdPos + pos ,

--- a/src/languagedefinition.cpp
+++ b/src/languagedefinition.cpp
@@ -97,7 +97,11 @@ namespace highlight
 	RegexDef LanguageDefinition::extractRegex ( const string &paramValue )
 	{
 		RegexDef re_def;
+#if __cplusplus >= 201103L
+		unique_ptr<Matcher> m ( reDefPattern->createMatcher ( paramValue ) );
+#else
 		auto_ptr<Matcher> m ( reDefPattern->createMatcher ( paramValue ) );
+#endif
 		if ( m.get() && m->matches() )
 		{
 			re_def.reString = m->getGroup ( 1 );


### PR DESCRIPTION
~~~
languagedefinition.cpp: In member function 'highlight::RegexDef highlight::LanguageDefinition::extractRegex(const string&)':
languagedefinition.cpp:100:3: warning: 'template<class> class std::auto_ptr' is deprecated [-Wdeprecated-declarations]
   auto_ptr<Matcher> m ( reDefPattern->createMatcher ( paramValue ) );
   ^~~~~~~~
In file included from /usr/include/c++/6.0.0/memory:81:0,
                 from languagedefinition.cpp:28:
/usr/include/c++/6.0.0/bits/unique_ptr.h:49:28: note: declared here
   template<typename> class auto_ptr;
                            ^~~~~~~~
~~~
